### PR TITLE
feat: :sparkles: Badge 컴포넌트 이관

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,48 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Icon from '@/components/commons/Icon';
+import Badge from './Badge';
+
+export default {
+  title: 'Commons/Badge',
+  component: Badge,
+  argTypes: {
+    label: { control: 'text', name: 'text' },
+    width: { control: 'text' },
+    type: { control: 'select', options: ['primary', 'secondary', 'ghost', 'default'] },
+    leftAddon: { control: 'boolean' },
+    rightAddon: { control: 'boolean' },
+  },
+  args: { likeCount: 100 },
+} as ComponentMeta<typeof Badge>;
+
+const Template: ComponentStory<typeof Badge> = ({ leftAddon, rightAddon, ...args }) => (
+  <Badge
+    {...args}
+    leftAddon={leftAddon ? <Icon name="Like" /> : undefined}
+    rightAddon={rightAddon ? <Icon name="Like" /> : undefined}
+  />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  label: '과일 향이 나요',
+};
+
+export const Primary = Template.bind({});
+Primary.args = {
+  type: 'primary',
+  label: '과일 향이 나요',
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  type: 'secondary',
+  label: '과일 향이 나요',
+};
+
+export const Ghost = Template.bind({});
+Ghost.args = {
+  type: 'ghost',
+  label: '과일 향이 나요',
+};

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import type { HTMLAttributes } from 'react';
+import cx from 'classnames';
+
+import { ColorTheme } from '@/themes/types';
+
+type BadgeType = 'primary' | 'secondary' | 'ghost' | 'default';
+
+interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
+  type?: BadgeType;
+  width?: string;
+  leftAddon?: React.ReactNode;
+  rightAddon?: React.ReactNode;
+  disabled?: boolean;
+  label?: React.ReactNode;
+  className?: string;
+}
+
+interface StyledBadgeProps {
+  badgeType: BadgeType;
+  badgeWidth?: string;
+}
+
+const Badge: React.FC<BadgeProps> = ({
+  type = 'default',
+  width,
+  className,
+  leftAddon,
+  rightAddon,
+  label,
+  ...attrs
+}) => {
+  return (
+    <StyledBadge badgeType={type} badgeWidth={width} className={className} {...attrs}>
+      {leftAddon && <span className="common-badge-icon-wrapper margin-right">{leftAddon}</span>}
+      <span className={cx('common-badge-text')}>{label}</span>
+      {rightAddon && <span className={`common-badge-icon-wrapper margin-left`}>{rightAddon}</span>}
+    </StyledBadge>
+  );
+};
+
+const getColorByType = (type: BadgeType, theme: ColorTheme) => {
+  switch (type) {
+    case 'primary':
+      return theme.semanticColor.primary;
+    case 'secondary':
+      return theme.semanticColor.secondary;
+    case 'ghost':
+      return theme.color.whiteOpacity0;
+    default:
+      return theme.color.whiteOpacity20;
+  }
+};
+
+const getFontColorByType = (type: BadgeType, theme: ColorTheme) => {
+  switch (type) {
+    case 'primary':
+      return theme.color.white;
+    case 'secondary':
+      return theme.semanticColor.backgroundLow;
+    case 'ghost':
+      return theme.color.white;
+    default:
+      return theme.semanticColor.secondary;
+  }
+};
+const StyledBadge = styled.div<StyledBadgeProps>`
+  background-color: ${({ theme, badgeType }) => getColorByType(badgeType, theme)};
+  color: ${({ theme, badgeType }) => getFontColorByType(badgeType, theme)};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  transition: filter 0.2s;
+  box-sizing: border-box;
+  width: fit-content;
+  ${({ badgeWidth }) => (badgeWidth ? ` width: ${badgeWidth};` : '')};
+
+  border-radius: 12px;
+  padding: 6px 11px;
+  height: 24px;
+
+  & > .common-badge-icon-wrapper {
+    height: 14px;
+
+    &.margin-right {
+      margin-right: 5px;
+    }
+    &.margin-left {
+      margin-left: 5px;
+    }
+
+    & svg {
+      width: 14px;
+      height: 14px;
+    }
+  }
+
+  & > .common-badge-text {
+    display: inline-block;
+    font-weight: 400;
+    font-size: 10px;
+    line-height: 12px;
+  }
+
+  &:active {
+    filter: brightness(80%);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    outline: ${({ theme }) => theme.color.whiteOpacity20} solid 2px;
+    outline-offset: -2px;
+    color: ${({ theme }) => theme.color.whiteOpacity20};
+    background-color: ${({ theme }) => theme.color.black80};
+  }
+`;
+
+export default Badge;

--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Badge';


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
<img width="91" alt="image" src="https://user-images.githubusercontent.com/60775453/180014244-35f045d9-9233-4215-b289-521d2108e598.png">


- `Badge` 네이밍이 적절한가? 
  - antd 에서는 Badge를 [다른 모양의 컴포넌트](https://ant.design/components/badge/#header)로 정의해 사용하고 있습니다 
  - 그렇다고 Chip으로 이름을 변경하기엔 이미 Chip 컴포넌트가 있습니다
  - antd에서 사용하고 있는 Badge 컴포넌트로 변경하기에는 이미 그 의미로 사용하고 있는 컴포넌트가 존재합니다 (선택한 숫자 개수 나타내는 styled 컴포넌트) 그리고 그 컴포넌트는 페이지 한 군데에서만 사용됩니다
  - 결론 : 현안 유지. 저희끼리 의미를 공유하고 사용하면 큰 문제 없다고 생각합니다! 혹시 좋은 네이밍 의견이 있다면 말씀해주세요ㅎㅎ
- yarn dev yarn storybook 을 통해 확인하였습니다
- 다른 변경사항 없습니다!

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
