### PR TITLE
feat: :zap: Me 컴포넌트 이관

### DIFF
--- a/src/components/Me/Me.stories.tsx
+++ b/src/components/Me/Me.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Me from './Me';
+
+export default {
+  title: 'Components/Me',
+  component: Me,
+} as ComponentMeta<typeof Me>;
+
+const Template: ComponentStory<typeof Me> = () => <Me />;
+
+export const Default = Template.bind({});

--- a/src/components/Me/Me.tsx
+++ b/src/components/Me/Me.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import type { HTMLAttributes } from 'react';
+
+interface Props extends HTMLAttributes<HTMLSpanElement> {
+  className?: string;
+}
+
+const Me = (props: Props) => {
+  const { className, ...rest } = props;
+
+  return (
+    <StyledMe className={className} {...rest}>
+      ME
+    </StyledMe>
+  );
+};
+
+export default Me;
+
+const StyledMe = styled.span`
+  ${({ theme }) => theme.fonts.SmallBold3};
+  color: ${({ theme }) => theme.color.white};
+  background-color: ${({ theme }) => theme.semanticColor.primary};
+  border-radius: 13px;
+  padding: 2px 8px;
+  height: 16px;
+`;

--- a/src/components/Me/index.ts
+++ b/src/components/Me/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Me';


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
- label을 받을 수 있도록 구현했으나, 맥주 상세페이지에서만 사용되는 특이 컴포넌트이므로 ME 스트링으로 단정지었습니다
- MeBadge 라는 이름에서 Badge가 어색한 것 같아 Me 로 변경합니다

<img width="41" alt="image" src="https://user-images.githubusercontent.com/60775453/180235436-0bdfabe0-93c1-4af4-82fd-69f2ce139cef.png">


## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
