### PR TITLE
feat: ✨ Header 컴포넌트 이관

### DIFF
--- a/src/components/commons/Header/Header.stories.tsx
+++ b/src/components/commons/Header/Header.stories.tsx
@@ -1,0 +1,52 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+import styled from '@emotion/styled';
+
+import Header from './Header';
+import { BackButton, CloseButton } from './extras';
+
+export default {
+  title: 'Commons/Header',
+  component: Header,
+  argTypes: {
+    isTransparent: { control: 'boolean', defaultValue: false },
+  },
+  decorators: [
+    (Story) => (
+      <main>
+        <Story />
+        {Array(100)
+          .fill(0)
+          .map((_, index) => (
+            <p key={index} style={{ color: 'white' }}>
+              스크롤
+            </p>
+          ))}
+      </main>
+    ),
+  ],
+} as ComponentMeta<typeof Header>;
+
+export const 뒤로가기_헤더: ComponentStoryObj<typeof Header> = {
+  args: {
+    leftExtras: <BackButton />,
+    children: '제목',
+  },
+};
+
+export const 닫기_헤더: ComponentStoryObj<typeof Header> = {
+  args: {
+    leftExtras: <CloseButton />,
+  },
+};
+
+const StyledSearchHeader = styled(Header)`
+  border-bottom: 1px solid ${(p) => p.theme.semanticColor.secondary};
+`;
+
+export const 맥주_검색_페이지: ComponentStoryObj<typeof Header> = {
+  render: (args) => <StyledSearchHeader {...args} />,
+  args: {
+    leftExtras: <BackButton />,
+    children: '검색창 컴포넌트',
+  },
+};

--- a/src/components/commons/Header/Header.tsx
+++ b/src/components/commons/Header/Header.tsx
@@ -1,0 +1,88 @@
+import { ReactNode } from 'react';
+import styled from '@emotion/styled';
+
+import { ellipsis } from '@/styles/common';
+
+export const HEADER_HEIGHT = 60;
+
+const StyledHeader = styled.header<Pick<HeaderProps, 'isTransparent'>>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: ${HEADER_HEIGHT}px;
+  padding: 0 20px;
+  z-index: 100;
+
+  background-color: ${(p) => (p.isTransparent ? 'transparent' : p.theme.color.black100)};
+  transition: background-color 0.5s;
+
+  > div {
+    display: flex;
+    align-items: center;
+  }
+`;
+
+const StyledLeftExtras = styled.div`
+  > *:not(:first-of-type) {
+    margin-left: 8px;
+  }
+
+  > *:last-child {
+    margin-right: 12px;
+  }
+`;
+
+const StyledRightExtras = styled.div`
+  > *:not(:last-child) {
+    margin-right: 8px;
+  }
+
+  > *:first-of-type {
+    margin-left: 12px;
+  }
+`;
+
+const StyledTitle = styled.div`
+  flex: 1;
+  height: 100%;
+`;
+
+const StyledH1 = styled.h1`
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 22px;
+  color: ${(p) => p.theme.color.white};
+
+  ${ellipsis()};
+`;
+
+interface HeaderProps {
+  children?: ReactNode;
+  /** 좌측 추가 컴포넌트 */
+  leftExtras?: ReactNode;
+  /** 우측 추가 컴포넌트 */
+  rightExtras?: ReactNode;
+  /** 배경 투명 여부 (default: false) */
+  isTransparent?: boolean;
+  className?: string;
+}
+
+const Header = ({
+  children,
+  leftExtras,
+  rightExtras,
+  isTransparent = false,
+  className,
+}: HeaderProps) => {
+  return (
+    <StyledHeader className={className} isTransparent={isTransparent}>
+      <StyledLeftExtras>{leftExtras}</StyledLeftExtras>
+      <StyledTitle>
+        {typeof children === 'string' ? <StyledH1>{children}</StyledH1> : children}
+      </StyledTitle>
+      <StyledRightExtras>{rightExtras}</StyledRightExtras>
+    </StyledHeader>
+  );
+};
+
+export default Header;

--- a/src/components/commons/Header/extras/BackButton.tsx
+++ b/src/components/commons/Header/extras/BackButton.tsx
@@ -1,0 +1,18 @@
+import { ButtonHTMLAttributes } from 'react';
+import { useRouter } from 'next/router';
+
+import Icon from '@/components/commons/Icon';
+
+interface BackButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {}
+
+const BackButton = ({ onClick, ...props }: BackButtonProps) => {
+  const router = useRouter();
+
+  return (
+    <button type="button" aria-label="뒤로가기" onClick={router.back} {...props}>
+      <Icon name="Back" color="whiteOpacity50" />
+    </button>
+  );
+};
+
+export default BackButton;

--- a/src/components/commons/Header/extras/CloseButton.tsx
+++ b/src/components/commons/Header/extras/CloseButton.tsx
@@ -1,0 +1,15 @@
+import { ButtonHTMLAttributes } from 'react';
+
+import Icon from '@/components/commons/Icon';
+
+interface CloseButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {}
+
+const CloseButton = (props: CloseButtonProps) => {
+  return (
+    <button type="button" aria-label="닫기" {...props}>
+      <Icon name="X" color="white" size={24} />
+    </button>
+  );
+};
+
+export default CloseButton;

--- a/src/components/commons/Header/extras/extras.stories.tsx
+++ b/src/components/commons/Header/extras/extras.stories.tsx
@@ -1,0 +1,56 @@
+import { ReactNode } from 'react';
+import styled from '@emotion/styled';
+
+import { BackButton, CloseButton } from '.';
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  title: 'Commons/Header/extras',
+  argTypes: {
+    type: { control: 'radio', options: ['grid', 'list'] },
+  },
+  args: {},
+};
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 12px 20px;
+
+  h1 {
+    ${(p) => p.theme.fonts.H1};
+    margin-bottom: 10px;
+  }
+`;
+
+const StyledRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 20px;
+
+  p {
+    ${(p) => p.theme.fonts.Body2};
+    margin-right: 10px;
+  }
+`;
+
+export const extras = () => {
+  const renderExtra = (name: string, extra: ReactNode) => {
+    return (
+      <StyledRow>
+        <p>{name}</p>
+        {extra}
+      </StyledRow>
+    );
+  };
+
+  return (
+    <StyledContainer>
+      <h1>Header extras</h1>
+      {renderExtra('BackButton', <BackButton />)}
+      {renderExtra('CloseButton', <CloseButton />)}
+    </StyledContainer>
+  );
+};

--- a/src/components/commons/Header/extras/index.tsx
+++ b/src/components/commons/Header/extras/index.tsx
@@ -1,0 +1,2 @@
+export { default as BackButton } from './BackButton';
+export { default as CloseButton } from './CloseButton';

--- a/src/components/commons/Header/index.ts
+++ b/src/components/commons/Header/index.ts
@@ -1,0 +1,1 @@
+export { default, HEADER_HEIGHT } from './Header';

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+
+/** @note 요소의 width가 존재해야 올바르게 동작합니다. */
+export const ellipsis = (lineCount = 1) => css`
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  word-break: ${lineCount === 1 ? 'break-all' : 'break-word'};
+  display: -webkit-box;
+  -webkit-line-clamp: ${lineCount};
+  -webkit-box-orient: vertical;
+`;
+
+/** @note 스크롤은 동작하나 스크롤 바는 보이지 않습니다.  */
+export const hideScrollbar = css`
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+
+  &::-webkit-scrollbar {
+    display: none;
+    width: 0 !important;
+  }
+`;


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

resolve #58 

헤더 컴포넌트 이관
- 기존에는 헤더에 들어갈 수 있는 모든 extras 컴포넌트를 헤더 Extra폴더 안에 정의 했지만
<img width="280" alt="image" src="https://user-images.githubusercontent.com/39763891/180374412-8c768f2a-1a40-4fc2-b7aa-8976efd169e1.png">

- 좋아요 토글 버튼 같은 경우 헤더 뿐만 아니라 맥주 아이템 컴포넌트에서도 사용되므로 헤더에 종속되게 구현하는 것이 안좋아 보여 뻈습니다 
- extras에는 뒤로가기 버튼과 닫기 버튼만 존재하고, 나머지는 header를 사용하는 컴포넌트 내부에서 정의하도록 하는것이 좋을 것 같아요!


## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
