### PR TITLE
BeerPhotoLabel 컴포넌트 이관

### DIFF
--- a/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.stories.tsx
+++ b/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.stories.tsx
@@ -1,0 +1,28 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { beer } from '@/constants/dummy';
+
+// import backgroundImage from '../../../.storybook/assets/beer_background.png';
+import BeerPhotoLabel from './BeerPhotoLabel';
+
+export default {
+  title: 'Components/beer/BeerPhotoLabel',
+  component: BeerPhotoLabel,
+  argTypes: {
+    beer: { control: 'readonly' },
+    background: { control: 'readonly' },
+  },
+} as ComponentMeta<typeof BeerPhotoLabel>;
+
+const Template: ComponentStory<typeof BeerPhotoLabel> = (args) => <BeerPhotoLabel {...args} />;
+
+export const BasicBeerPhotoLabel = Template.bind({});
+BasicBeerPhotoLabel.args = {
+  beer,
+};
+
+export const BackgroundBeerTicketTitle = Template.bind({});
+BackgroundBeerTicketTitle.args = {
+  beer,
+  background: 'https://beerair-service.s3.ap-northeast-2.amazonaws.com/samples/beer_background.png',
+};

--- a/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.stories.tsx
+++ b/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.stories.tsx
@@ -2,7 +2,6 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { beer } from '@/constants/dummy';
 
-// import backgroundImage from '../../../.storybook/assets/beer_background.png';
 import BeerPhotoLabel from './BeerPhotoLabel';
 
 export default {

--- a/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.tsx
+++ b/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.tsx
@@ -10,10 +10,6 @@ interface BeerPhotoLabelProps {
   background?: string;
 }
 
-interface StyledBeerPhotoLabelProps {
-  ticketBackground?: string;
-}
-
 const BeerPhotoLabel: React.FC<BeerPhotoLabelProps> = ({ background, beer }) => (
   <StyledBeerPhotoLabel ticketBackground={background}>
     {background && <div className="ticket-background-img" />}
@@ -31,6 +27,10 @@ const BeerPhotoLabel: React.FC<BeerPhotoLabelProps> = ({ background, beer }) => 
     <span className="beer-name">{beer.nameKor}</span>
   </StyledBeerPhotoLabel>
 );
+
+interface StyledBeerPhotoLabelProps {
+  ticketBackground?: string;
+}
 
 const StyledBeerPhotoLabel = styled.div<StyledBeerPhotoLabelProps>`
   position: relative;

--- a/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.tsx
+++ b/src/components/beer/BeerPhotoLabel/BeerPhotoLabel.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import { IBeer } from '@/types';
+import Icon from '@/components/commons/Icon';
+import { sliceAndUpperCase } from '@/utils/string';
+
+interface BeerPhotoLabelProps {
+  beer: IBeer;
+  background?: string;
+}
+
+interface StyledBeerPhotoLabelProps {
+  ticketBackground?: string;
+}
+
+const BeerPhotoLabel: React.FC<BeerPhotoLabelProps> = ({ background, beer }) => (
+  <StyledBeerPhotoLabel ticketBackground={background}>
+    {background && <div className="ticket-background-img" />}
+    <div>
+      <Icon name="Airplane" size={20} color="whiteOpacity35" />
+    </div>
+    <div className="beer-photo-title">
+      <span className="beer-country">{sliceAndUpperCase(beer.country?.nameEng || 'non', 3)}</span>
+      <div className="beer-label-detail">
+        {`${beer.alcohol.toFixed(1)}%`}
+        <span className="beer-label-detail-split-dot">{'•'}</span>
+        {beer.type?.nameKor}
+      </div>
+    </div>
+    <span className="beer-name">{beer.nameKor}</span>
+  </StyledBeerPhotoLabel>
+);
+
+const StyledBeerPhotoLabel = styled.div<StyledBeerPhotoLabelProps>`
+  position: relative;
+  background: ${({ theme }) => theme.semanticColor.primary};
+  color: ${({ theme }) => theme.color.white};
+  width: 100%;
+  height: 180px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+
+  & > .beer-photo-title {
+    display: flex;
+    align-items: flex-end;
+    margin: 10px 0 18px;
+
+    & > .beer-country {
+      ${({ theme }) => theme.fonts.Abbr1}
+      line-height: 30px;
+    }
+
+    & > .beer-label-detail {
+      ${({ theme }) => theme.fonts.SmallBold3}
+      color: ${({ theme }) => theme.color.whiteOpacity65};
+      margin-left: 8px;
+
+      & > .beer-label-detail-split-dot {
+        margin: 0 4px;
+      }
+    }
+  }
+
+  & > .ticket-background-img {
+    background-image: url(${({ ticketBackground }) => ticketBackground});
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    left: 0;
+    top: 0;
+    background-repeat: no-repeat;
+    background-position: right;
+    mask-image: linear-gradient(253.61deg, rgba(0, 0, 0, 0.6) 0%, rgba(255, 255, 255, 0) 65.72%);
+    filter: grayscale(100%);
+  }
+
+  & > .beer-name {
+    ${({ theme }) => theme.fonts.H5}
+    display: inline-block;
+    width: 60%;
+    word-break: keep-all;
+    text-align: left;
+  }
+`;
+
+export default BeerPhotoLabel;

--- a/src/components/beer/BeerPhotoLabel/index.ts
+++ b/src/components/beer/BeerPhotoLabel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BeerPhotoLabel';

--- a/src/constants/dummy.ts
+++ b/src/constants/dummy.ts
@@ -1,0 +1,43 @@
+import { BeerType } from '@/types';
+
+export const beer = {
+  id: 1,
+  country: {
+    id: 1,
+    nameKor: '한국',
+    nameEng: 'korea',
+    imageUrl: 'https://beerair-service.s3.ap-northeast-2.amazonaws.com/samples/korea.png',
+    backgroundImageUrl:
+      'https://beerair-service.s3.ap-northeast-2.amazonaws.com/samples/korea-bg.png',
+    continent: {
+      id: 1,
+      name: '아시아',
+    },
+  },
+  type: {
+    nameEng: BeerType.LIGHT_ALE,
+    nameKor: '위트 에일',
+    imageUrl: '',
+    description: '투명한 황금빛으로 단 맛과 쓴 맛이 어우러진 깔끔한 맛',
+  },
+  startCountry: {
+    nameKor: '한국',
+    nameEng: 'korea',
+  },
+  endCountry: {
+    nameKor: '미국',
+    nameEng: 'usa',
+  },
+  nameKor: '제주 위트 에일',
+  nameEng: 'Jeju Wit Ale Jeju Wit Ale Jeju Wit Ale Jeju Wit Ale Jeju Wit Ale Jeju Wit Ale',
+  imageUrl: 'https://beerair-service.s3.ap-northeast-2.amazonaws.com/samples/kumiho_peach_ale.png',
+  content:
+    '‘제주 위트 에일’은 제주 청정 재료인 유기농 제주 감귤 껍질을 사용해 은은한 감귤 향의 산뜻한 끝 맛이 특징이다. 독일산 보리 맥아와 밀 맥아를 함께 사용해 부드러운 음용감으로 에일 맥주 입문자들도 편하게 즐길 수 있다.',
+  alcohol: 5.5,
+  price: 4200,
+  volume: 50,
+  feel: 4,
+  isLiked: false,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,2 @@
+export const sliceAndUpperCase = (str: string, length: number) =>
+  str?.slice(0, length).toUpperCase();


### PR DESCRIPTION
## 📍 주요 변경사항
- 기존 BeerTicketTitle -> BeerPhotoLabel 컴포넌트 이관
- sliceAndUpperCase util 이관

## 🔗 참고자료
<img width="412" alt="image" src="https://user-images.githubusercontent.com/49899406/182154274-d5e8077f-0a5d-4d95-a914-1bfbfc3f679e.png">

## 💡 중점적으로 봐주었으면 하는 부분
- 네이밍은 기존에 Ticket에 종속되어 있는 이름인데 실제로 업로드시에도 사용하기 때문에 공통되는 이름으로 변경
- 기존 constant에 각각 beer 와 같이 선언해놓았던 dummy 데이터를 constant/dummy 로 통합함
  - 실제 운영상의 코드에서는 사용되지 않고, storybook이나, 개발 도중 테스트를 위해서만 사용되기 때문에 해당 파일에 격리해놓음
- 기존에는 type prop을 받아 크기를 하나하나 분기쳐서 구현했지만, 사용할 때 scale을 써서 직접 크기를 조정하는 방향으로 분리
  - 대부분 기본 크기를 쓰고, 티켓같은 경우에서 사용할 때 티켓의 크기도 제각각이기 때문에 분기코드가 너무 많아짐, scale이 더 깔끔할 것 같아 크기 조정 분기 코드 모두 제거
