### PR TITLE
feat: :sparkles: NicknameModifyModal 컴포넌트 이관

### DIFF
--- a/src/components/mypage/NicknameModifyModal/NicknameModifyModal.stories.tsx
+++ b/src/components/mypage/NicknameModifyModal/NicknameModifyModal.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { useState } from 'react';
+
+import NicknameModifyModal from './NicknameModifyModal';
+
+export default {
+  title: 'Components/mypage/NicknameModifyModal',
+  component: NicknameModifyModal,
+} as ComponentMeta<typeof NicknameModifyModal>;
+
+const Template: ComponentStory<typeof NicknameModifyModal> = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <NicknameModifyModal open={isOpen} closeModal={() => setIsOpen(false)} onSubmit={() => {}} />
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/mypage/NicknameModifyModal/NicknameModifyModal.tsx
+++ b/src/components/mypage/NicknameModifyModal/NicknameModifyModal.tsx
@@ -35,7 +35,7 @@ const NicknameModifyModal = ({ open, closeModal, onSubmit }: Props) => {
       header="닉네임 수정하기"
       withCloseButton
       description={
-        <InputContainer onSubmit={onSubmit}>
+        <StyledForm onSubmit={onSubmit}>
           <StyledInput
             id="nickname"
             type="text"
@@ -54,7 +54,7 @@ const NicknameModifyModal = ({ open, closeModal, onSubmit }: Props) => {
           />
           {errors.nickname?.message && <p className="error-text">{errors.nickname.message}</p>}
           <p className="helper-text">최대 15글자까지 입력할 수 있습니다</p>
-        </InputContainer>
+        </StyledForm>
       }
       buttons={
         <Button
@@ -72,7 +72,7 @@ const NicknameModifyModal = ({ open, closeModal, onSubmit }: Props) => {
 
 export default NicknameModifyModal;
 
-const InputContainer = styled.form`
+const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/mypage/NicknameModifyModal/NicknameModifyModal.tsx
+++ b/src/components/mypage/NicknameModifyModal/NicknameModifyModal.tsx
@@ -1,0 +1,105 @@
+import styled from '@emotion/styled';
+
+import Modal from '@/components/Modal';
+import Button from '@/components/commons/Button';
+import { useForm } from 'react-hook-form';
+
+const LETTERS_REGEX = /^[가-힣A-Za-z0-9]*$/i;
+
+interface Props {
+  open: boolean;
+  closeModal: () => void;
+  onSubmit: () => void;
+}
+
+interface FormState {
+  nickname: string;
+}
+
+const NicknameModifyModal = ({ open, closeModal, onSubmit }: Props) => {
+  const {
+    register,
+    watch,
+    formState: { isValid, isDirty, errors },
+    handleSubmit,
+  } = useForm<FormState>({
+    mode: 'onChange',
+  });
+
+  const { nickname } = watch();
+
+  return (
+    <Modal
+      open={open}
+      closeModal={closeModal}
+      header="닉네임 수정하기"
+      withCloseButton
+      description={
+        <InputContainer onSubmit={onSubmit}>
+          <StyledInput
+            id="nickname"
+            type="text"
+            value={nickname}
+            placeholder="닉네임 입력"
+            maxLength={15}
+            defaultValue=""
+            {...register('nickname', {
+              maxLength: 15,
+              required: '닉네임을 입력해주세요',
+              pattern: {
+                value: LETTERS_REGEX,
+                message: '올바른 값을 입력해주세요',
+              },
+            })}
+          />
+          {errors.nickname?.message && <p className="error-text">{errors.nickname.message}</p>}
+          <p className="helper-text">최대 15글자까지 입력할 수 있습니다</p>
+        </InputContainer>
+      }
+      buttons={
+        <Button
+          type="primary"
+          width="large"
+          disabled={!isDirty || !isValid}
+          onClick={handleSubmit(onSubmit)}
+        >
+          완료
+        </Button>
+      }
+    />
+  );
+};
+
+export default NicknameModifyModal;
+
+const InputContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .helper-text {
+    ${({ theme }) => theme.fonts.Body1};
+    color: ${({ theme }) => theme.color.grey3};
+  }
+  .error-text {
+    ${({ theme }) => theme.fonts.Body1};
+    color: ${({ theme }) => theme.color.red};
+    margin-bottom: 5px;
+  }
+`;
+
+const StyledInput = styled.input`
+  width: 240px;
+  height: 40px;
+  border: none;
+  border-bottom: 1px solid ${({ theme }) => theme.color.grey2};
+  margin-top: 52px;
+  margin-bottom: 12px;
+  ${({ theme }) => theme.fonts.SubTitle2};
+  color: ${({ theme }) => theme.color.black100};
+  text-align: center;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.grey4};
+  }
+`;

--- a/src/components/mypage/NicknameModifyModal/index.ts
+++ b/src/components/mypage/NicknameModifyModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NicknameModifyModal';


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
- react-hook-form 을 도입하여 닉네임 validation 추가
  - 자음과 모음으로 이루어진 조합이 아니면 에러메세지 표기 (ex. ㅋㅋㅋ)
- 기존에 ModalLayout으로 작성된 컴포넌트를 Modal 컴포넌트를 이용해 리팩토링
- Button에 isDirty, isValid 값에 따라 disabled 처리

<img width="330" alt="image" src="https://user-images.githubusercontent.com/60775453/182675815-17cbf951-c751-453f-b350-39df25c93a9b.png">


<img width="335" alt="image" src="https://user-images.githubusercontent.com/60775453/182671965-93f6c6dd-68ec-4703-b215-634780b405d1.png">

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
개인적인 의견으로는, '최대 15글자까지 입력할 수 있습니다'도 상시노출하지 않고 에러메세지로 처리하는게 깔끔하다고 생각합니다
